### PR TITLE
2020 11 5 event descriptor min max no outcomes

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
@@ -1,0 +1,253 @@
+package org.bitcoins.core.protocol.tlv
+
+import org.bitcoins.core.number.{Int32, UInt16, UInt32}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+
+import scala.collection.immutable.NumericRange
+import scala.math.Numeric.BigDecimalAsIfIntegral
+
+class EventDescriptorTest extends BitcoinSUnitTest {
+
+  behavior of "EventDescriptor"
+
+  it must "create an enumerated event" in {
+    val outcomes = Vector("Democrat_win", "Republican_win", "other")
+    val enumEventDescriptorV0TLV = EnumEventDescriptorV0TLV(outcomes)
+
+    assert(enumEventDescriptorV0TLV.outcomes == outcomes.map(Vector(_)))
+    assert(enumEventDescriptorV0TLV.noncesNeeded == 1)
+  }
+
+  it must "create a range event" in {
+    val rangeEventDescriptorV0TLV =
+      RangeEventDescriptorV0TLV(start = Int32(-2),
+                                count = UInt32(4),
+                                step = UInt16.one,
+                                unit = "test_unit",
+                                precision = Int32.zero)
+
+    assert(rangeEventDescriptorV0TLV.maxNum == 1)
+    assert(rangeEventDescriptorV0TLV.minNum == -2)
+    assert(
+      rangeEventDescriptorV0TLV.outcomes == Vector("-2", "-1", "0", "1").map(
+        Vector(_)))
+    assert(
+      rangeEventDescriptorV0TLV.outcomeNums
+        .map(_.toInt) == Vector(-2, -1, 0, 1))
+
+    val rangeEventBasePrecision1 =
+      RangeEventDescriptorV0TLV(start = Int32(0),
+                                count = UInt32(15),
+                                step = UInt16.one,
+                                unit = "test_unit",
+                                precision = Int32(2))
+
+    assert(rangeEventBasePrecision1.maxNum == 14)
+    assert(rangeEventBasePrecision1.maxToPrecision == 1400)
+    assert(rangeEventBasePrecision1.minNum == 0)
+    assert(rangeEventBasePrecision1.minToPrecision == 0)
+    val rangePrecision1 =
+      NumericRange
+        .inclusive[BigDecimal](start = 0, end = 1400, step = 100)(
+          BigDecimalAsIfIntegral)
+        .toVector
+    assert(rangeEventBasePrecision1.outcomesToPrecision == rangePrecision1)
+    assert(
+      rangeEventBasePrecision1.outcomes == 0
+        .until(15)
+        .map(num => Vector(num.toString)))
+  }
+
+  it must "handle a range event with negative precision" in {
+    //https://suredbits.slack.com/archives/CVA6LJA4E/p1604514328172300?thread_ts=1604507650.160900&cid=CVA6LJA4E
+    val rangeEventBasePrecision1 =
+      RangeEventDescriptorV0TLV(start = Int32(-10),
+                                count = UInt32(20),
+                                step = UInt16(5),
+                                unit = "test_unit",
+                                precision = Int32.negOne)
+    val range =
+      NumericRange[BigDecimal](start = -1.0, end = 9.0, step = 0.5)(
+        BigDecimalAsIfIntegral).toVector
+    assert(rangeEventBasePrecision1.stepToPrecision == 0.5)
+    assert(rangeEventBasePrecision1.minNum == -10)
+    assert(rangeEventBasePrecision1.minToPrecision == -1)
+    assert(rangeEventBasePrecision1.maxNum == 85)
+    assert(rangeEventBasePrecision1.maxToPrecision == 8.5)
+    assert(rangeEventBasePrecision1.outcomesToPrecision == range)
+
+    assert(
+      rangeEventBasePrecision1.outcomes == -10
+        .until(90, 5)
+        .map(num => Vector(num.toString())))
+  }
+
+  it must "be illegal to have num digits be zero" in {
+    intercept[IllegalArgumentException] {
+      UnsignedDigitDecompositionEventDescriptor(base = UInt16(10),
+                                                numDigits = UInt16.zero,
+                                                unit = "BTC/USD",
+                                                precision = Int32.zero)
+    }
+    intercept[IllegalArgumentException] {
+      SignedDigitDecompositionEventDescriptor(base = UInt16(10),
+                                              numDigits = UInt16.zero,
+                                              unit = "test_unit",
+                                              precision = Int32.zero)
+    }
+  }
+
+  it must "serialize and deserialize a range event" in {
+    val hex = "fdd80815fffffffe0000000400010642544355534400000000"
+    val re = RangeEventDescriptorV0TLV(start = Int32(-2),
+                                       count = UInt32(4),
+                                       step = UInt16.one,
+                                       unit = "BTCUSD",
+                                       precision = Int32.zero)
+
+    val reFromHex = RangeEventDescriptorV0TLV.fromHex(hex)
+    assert(reFromHex == re)
+    assert(re.hex == hex)
+  }
+
+  it must "create a unsigned digit decomposition event" in {
+    val descriptor =
+      UnsignedDigitDecompositionEventDescriptor(base = UInt16(10),
+                                                numDigits = UInt16(1),
+                                                unit = "BTC/USD",
+                                                precision = Int32.zero)
+
+    assert(descriptor.maxNum == 9)
+    assert(descriptor.minNum == 0)
+    val range = 0.until(10).toVector
+    assert(descriptor.outcomeNums.map(_.toInt) == range)
+    assert(descriptor.outcomes == range.map(num => Vector(num.toString)))
+
+    val descriptor1 = descriptor.copy(numDigits = UInt16(2))
+    assert(descriptor1.maxNum == 99)
+    assert(descriptor1.minNum == 0)
+    val expected1 = 0.until(100).toVector
+    val expectedString1 = expected1.map { num =>
+      String.format("%02d", num).toVector.map(_.toString)
+    }
+    assert(descriptor1.outcomeNums.map(_.toInt) == expected1)
+    assert(descriptor1.outcomes == expectedString1)
+
+    val descriptor2 = descriptor.copy(precision = Int32.negOne)
+
+    assert(descriptor2.maxNum == 9)
+    assert(descriptor2.maxToPrecision == 0.9)
+    assert(descriptor2.minNum == 0)
+    assert(descriptor2.minToPrecision == 0)
+    val expectedString2 = 0.until(10).toVector.map(num => Vector(num.toString))
+    assert(descriptor2.outcomes == expectedString2)
+    assert(
+      descriptor2.outcomesToPrecision.map(_.toDouble) == Vector(0.0, 0.1, 0.2,
+        0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9))
+
+    val descriptor3 =
+      descriptor.copy(precision = Int32.negOne, numDigits = UInt16(2))
+
+    assert(descriptor3.maxNum == 99)
+    assert(descriptor3.maxToPrecision == 9.9)
+    assert(descriptor3.minNum == 0)
+    assert(descriptor3.minToPrecision == 0.0)
+    val expected3 =
+      NumericRange[BigDecimal](start = 0.0, end = 10.0, step = 0.1)(
+        BigDecimalAsIfIntegral).toVector
+    assert(descriptor3.outcomesToPrecision == expected3)
+
+    val expectedStrings3: Vector[Vector[String]] =
+      0.until(100).toVector.map { num =>
+        String.format("%02d", num).toVector.map(_.toString)
+      }
+
+    assert(descriptor3.outcomes == expectedStrings3)
+  }
+
+  def formatNum(num: Int, numDigits: Int): Vector[String] = {
+    val sign = if (num < 0) {
+      "-"
+    } else {
+      "+"
+    }
+
+    val digits =
+      String.format(s"%0${numDigits}d", Math.abs(num)).toVector.map(_.toString)
+
+    sign +: digits
+  }
+
+  it must "create a signed digit decomposition event" in {
+    val descriptor =
+      SignedDigitDecompositionEventDescriptor(base = UInt16(10),
+                                              numDigits = UInt16(1),
+                                              unit = "BTC/USD",
+                                              precision = Int32.zero)
+
+    val descriptorOutcomeNums = -9.until(10).toVector
+    val descriptorOutcomes =
+      descriptorOutcomeNums.map(formatNum(_, numDigits = 1))
+    assert(descriptor.outcomes == descriptorOutcomes)
+    assert(descriptor.outcomeNums.map(_.toInt) == descriptorOutcomeNums)
+
+    val descriptor1 = descriptor.copy(precision = Int32.negOne)
+
+    val expected =
+      NumericRange[BigDecimal](start = -0.9, end = 1.0, step = 0.1)(
+        BigDecimalAsIfIntegral).toVector
+
+    assert(descriptor1.maxNum == 9)
+    assert(descriptor1.maxToPrecision == 0.9)
+    assert(descriptor1.minNum == -9)
+    assert(descriptor1.minToPrecision == -0.9)
+    assert(descriptor1.outcomesToPrecision == expected)
+    assert(descriptor1.outcomes == descriptorOutcomes)
+
+    val descriptor2 = descriptor1.copy(precision = Int32(-2))
+
+    assert(descriptor2.minToPrecision == -0.09)
+    assert(descriptor2.maxToPrecision == 0.09)
+    val expected2 =
+      NumericRange[BigDecimal](start = -0.09, end = 0.1, step = 0.01)(
+        BigDecimalAsIfIntegral).toVector
+
+    assert(descriptor2.outcomesToPrecision == expected2)
+    assert(descriptor2.outcomes == descriptorOutcomes)
+
+    val descriptor3 = descriptor2.copy(numDigits = UInt16(2))
+    assert(descriptor3.minNum == -99)
+    assert(descriptor3.minToPrecision == -0.99)
+    assert(descriptor3.maxNum == 99)
+    assert(descriptor3.maxToPrecision == 0.99)
+    val expected3 =
+      NumericRange[BigDecimal](start = -0.99, end = 1, step = 0.01)(
+        BigDecimalAsIfIntegral).toVector
+
+    assert(descriptor3.outcomesToPrecision == expected3)
+    assert(
+      descriptor3.outcomes == -99
+        .until(100)
+        .toVector
+        .map(formatNum(_, numDigits = 2)))
+
+    val descriptor4 =
+      descriptor3.copy(numDigits = UInt16(3), precision = Int32(-1))
+
+    assert(descriptor4.maxNum == 999)
+    assert(descriptor4.maxToPrecision == 99.9)
+    assert(descriptor4.minNum == -999)
+    assert(descriptor4.minToPrecision == -99.9)
+
+    val expected4 =
+      NumericRange[BigDecimal](start = -99.9, end = 100, step = 0.1)(
+        BigDecimalAsIfIntegral).toVector
+
+    assert(descriptor4.outcomesToPrecision == expected4)
+    assert(
+      descriptor4.outcomes == -999
+        .until(1000)
+        .toVector
+        .map(formatNum(_, numDigits = 3)))
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
@@ -161,19 +161,6 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(expectedOutcomes3.forall(descriptor3.contains(_)))
   }
 
-  def formatNum(num: Int, numDigits: Int): Vector[String] = {
-    val sign = if (num < 0) {
-      "-"
-    } else {
-      "+"
-    }
-
-    val digits =
-      String.format(s"%0${numDigits}d", Math.abs(num)).toVector.map(_.toString)
-
-    sign +: digits
-  }
-
   it must "create a signed digit decomposition event" in {
     val descriptor =
       SignedDigitDecompositionEventDescriptor(base = UInt16(10),
@@ -182,8 +169,6 @@ class EventDescriptorTest extends BitcoinSUnitTest {
                                               precision = Int32.zero)
 
     val descriptorOutcomeNums: Vector[Int] = -9.until(10).toVector
-    val descriptorOutcomes =
-      descriptorOutcomeNums.map(formatNum(_, numDigits = 1))
 
     assert(descriptorOutcomeNums.forall(descriptor.contains(_)))
     assert(descriptorOutcomeNums.forall(descriptor.containsToPrecision(_)))

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
@@ -14,7 +14,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     val outcomes = Vector("Democrat_win", "Republican_win", "other")
     val enumEventDescriptorV0TLV = EnumEventDescriptorV0TLV(outcomes)
 
-    assert(enumEventDescriptorV0TLV.outcomes == outcomes.map(Vector(_)))
+    assert(enumEventDescriptorV0TLV.outcomes == outcomes)
     assert(enumEventDescriptorV0TLV.noncesNeeded == 1)
   }
 
@@ -31,7 +31,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(Vector(-2, -1, 0, 1).forall(rangeEventDescriptorV0TLV.contains(_)))
     assert(
       Vector(-2, -1, 0, 1).forall(
-        rangeEventDescriptorV0TLV.containsToPrecision(_)))
+        rangeEventDescriptorV0TLV.containsPreciseOutcome(_)))
 
     val rangeEventBasePrecision1 =
       RangeEventDescriptorV0TLV(start = Int32(0),
@@ -50,7 +50,8 @@ class EventDescriptorTest extends BitcoinSUnitTest {
           BigDecimalAsIfIntegral)
         .toVector
     assert(
-      rangePrecision1.forall(rangeEventBasePrecision1.containsToPrecision(_)))
+      rangePrecision1.forall(
+        rangeEventBasePrecision1.containsPreciseOutcome(_)))
     val expected = 0.until(15).toVector
     assert(expected.forall(rangeEventBasePrecision1.contains(_)))
   }
@@ -71,7 +72,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(rangeEventBasePrecision1.minToPrecision == -1)
     assert(rangeEventBasePrecision1.maxNum == 85)
     assert(rangeEventBasePrecision1.maxToPrecision == 8.5)
-    assert(range.forall(rangeEventBasePrecision1.containsToPrecision(_)))
+    assert(range.forall(rangeEventBasePrecision1.containsPreciseOutcome(_)))
 
     assert(
       -10
@@ -79,8 +80,8 @@ class EventDescriptorTest extends BitcoinSUnitTest {
         .toVector
         .forall(rangeEventBasePrecision1.contains(_)))
 
-    assert(!rangeEventBasePrecision1.containsToPrecision(8.4))
-    assert(rangeEventBasePrecision1.containsToPrecision(8.5))
+    assert(!rangeEventBasePrecision1.containsPreciseOutcome(8.4))
+    assert(rangeEventBasePrecision1.containsPreciseOutcome(8.5))
   }
 
   it must "be illegal to have num digits be zero" in {
@@ -121,14 +122,14 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(descriptor.maxNum == 9)
     assert(descriptor.minNum == 0)
     val range = 0.until(10).toVector
-    assert(range.forall(descriptor.containsToPrecision(_)))
+    assert(range.forall(descriptor.containsPreciseOutcome(_)))
     assert(range.forall(descriptor.contains(_)))
 
     val descriptor1 = descriptor.copy(numDigits = UInt16(2))
     assert(descriptor1.maxNum == 99)
     assert(descriptor1.minNum == 0)
     val expected1 = 0.until(100).toVector
-    assert(expected1.forall(descriptor1.containsToPrecision(_)))
+    assert(expected1.forall(descriptor1.containsPreciseOutcome(_)))
     assert(expected1.forall(descriptor1.contains(_)))
 
     val descriptor2 = descriptor.copy(precision = Int32.negOne)
@@ -141,7 +142,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(expectedString2.forall(descriptor2.contains(_)))
     assert(
       Vector(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9).forall(
-        descriptor2.containsToPrecision(_)))
+        descriptor2.containsPreciseOutcome(_)))
 
     val descriptor3 =
       descriptor.copy(precision = Int32.negOne, numDigits = UInt16(2))
@@ -153,7 +154,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     val expected3 =
       NumericRange[BigDecimal](start = 0.0, end = 10.0, step = 0.1)(
         BigDecimalAsIfIntegral).toVector
-    assert(expected3.forall(descriptor3.containsToPrecision(_)))
+    assert(expected3.forall(descriptor3.containsPreciseOutcome(_)))
 
     val expectedOutcomes3: Vector[Int] =
       0.until(100).toVector
@@ -171,7 +172,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     val descriptorOutcomeNums: Vector[Int] = -9.until(10).toVector
 
     assert(descriptorOutcomeNums.forall(descriptor.contains(_)))
-    assert(descriptorOutcomeNums.forall(descriptor.containsToPrecision(_)))
+    assert(descriptorOutcomeNums.forall(descriptor.containsPreciseOutcome(_)))
 
     val descriptor1 = descriptor.copy(precision = Int32.negOne)
 
@@ -183,7 +184,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(descriptor1.maxToPrecision == 0.9)
     assert(descriptor1.minNum == -9)
     assert(descriptor1.minToPrecision == -0.9)
-    assert(expected.forall(descriptor1.containsToPrecision(_)))
+    assert(expected.forall(descriptor1.containsPreciseOutcome(_)))
     assert(0.until(10).forall(descriptor1.contains(_)))
 
     val descriptor2 = descriptor1.copy(precision = Int32(-2))
@@ -194,7 +195,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
       NumericRange[BigDecimal](start = -0.09, end = 0.1, step = 0.01)(
         BigDecimalAsIfIntegral).toVector
 
-    assert(expected2.forall(descriptor2.containsToPrecision(_)))
+    assert(expected2.forall(descriptor2.containsPreciseOutcome(_)))
     assert(-9.until(10).toVector.forall(descriptor2.contains(_)))
 
     val descriptor3 = descriptor2.copy(numDigits = UInt16(2))
@@ -206,7 +207,7 @@ class EventDescriptorTest extends BitcoinSUnitTest {
       NumericRange[BigDecimal](start = -0.99, end = 1, step = 0.01)(
         BigDecimalAsIfIntegral).toVector
 
-    assert(expected3.forall(descriptor3.containsToPrecision(_)))
+    assert(expected3.forall(descriptor3.containsPreciseOutcome(_)))
     assert(
       -99
         .until(100)
@@ -225,14 +226,14 @@ class EventDescriptorTest extends BitcoinSUnitTest {
       NumericRange[BigDecimal](start = -99.9, end = 100, step = 0.1)(
         BigDecimalAsIfIntegral).toVector
 
-    assert(expected4.forall(descriptor4.containsToPrecision(_)))
+    assert(expected4.forall(descriptor4.containsPreciseOutcome(_)))
     assert(
       -999
         .until(1000)
         .toVector
         .forall(descriptor4.contains(_)))
 
-    assert(!descriptor4.containsToPrecision(13.55))
-    assert(descriptor4.containsToPrecision(13.5))
+    assert(!descriptor4.containsPreciseOutcome(13.55))
+    assert(descriptor4.containsPreciseOutcome(13.5))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/EventDescriptorTest.scala
@@ -79,7 +79,10 @@ class EventDescriptorTest extends BitcoinSUnitTest {
     assert(
       rangeEventBasePrecision1.outcomes == -10
         .until(90, 5)
-        .map(num => Vector(num.toString())))
+        .map(num => Vector(num.toString)))
+
+    assert(!rangeEventBasePrecision1.containsToPrecision(8.4))
+    assert(rangeEventBasePrecision1.containsToPrecision(8.5))
   }
 
   it must "be illegal to have num digits be zero" in {
@@ -249,5 +252,8 @@ class EventDescriptorTest extends BitcoinSUnitTest {
         .until(1000)
         .toVector
         .map(formatNum(_, numDigits = 3)))
+
+    assert(!descriptor4.containsToPrecision(13.55))
+    assert(descriptor4.containsToPrecision(13.5))
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -487,6 +487,7 @@ object Int32
     0.until(256).map(i => Int32(BigInt(i))).toVector
   }
 
+  val negOne = Int32(-1)
   val zero = cached(0)
   val one = cached(1)
   val two = cached(2)

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -319,6 +319,12 @@ trait NumericEventDescriptor extends EventDescriptorTLV {
     NumericRange.inclusive[BigInt](minNum, maxNum, step.toInt).toVector
   }
 
+  def contains(outcome: BigInt): Boolean = {
+    val inBounds = outcome <= maxNum && outcome >= minNum
+
+    inBounds && (outcome - minNum) % step.toInt == 0
+  }
+
   /** The base in which the outcome value is represented */
   def base: UInt16
 
@@ -343,6 +349,13 @@ trait NumericEventDescriptor extends EventDescriptorTLV {
 
   def outcomesToPrecision: Vector[BigDecimal] =
     outcomeNums.map(num => precisionModifier * BigDecimal(num))
+
+  def containsToPrecision(outcome: BigDecimal): Boolean = {
+    (outcome / precisionModifier).toBigIntExact match {
+      case Some(unModifiedOutcome) => contains(unModifiedOutcome)
+      case None                    => false
+    }
+  }
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -13,8 +13,6 @@ import org.bitcoins.core.protocol.tlv.TLV.{
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
 
-import scala.collection.immutable.NumericRange
-
 sealed trait TLV extends NetworkElement {
   def tpe: BigSizeUInt
   def value: ByteVector
@@ -235,9 +233,6 @@ object PongTLV extends TLVFactory[PongTLV] {
 
 sealed trait EventDescriptorTLV extends TLV {
   def noncesNeeded: Int
-
-  // TODO: Make all Vector[String] -> DLCOutcomeType when that type is introduced
-  def outcomes: Vector[Vector[String]]
 }
 
 object EventDescriptorTLV extends TLVParentFactory[EventDescriptorTLV] {
@@ -259,7 +254,7 @@ case class EnumEventDescriptorV0TLV(outcomeStrs: Vector[String])
     extends EventDescriptorTLV {
   override def tpe: BigSizeUInt = EnumEventDescriptorV0TLV.tpe
 
-  override lazy val outcomes: Vector[Vector[String]] =
+  lazy val outcomes: Vector[Vector[String]] =
     outcomeStrs.map(Vector(_))
 
   override val value: ByteVector = {
@@ -315,10 +310,6 @@ trait NumericEventDescriptor extends EventDescriptorTLV {
 
   def step: UInt16
 
-  def outcomeNums: Vector[BigInt] = {
-    NumericRange.inclusive[BigInt](minNum, maxNum, step.toInt).toVector
-  }
-
   def contains(outcome: BigInt): Boolean = {
     val inBounds = outcome <= maxNum && outcome >= minNum
 
@@ -346,9 +337,6 @@ trait NumericEventDescriptor extends EventDescriptorTLV {
   def minToPrecision: BigDecimal = precisionModifier * BigDecimal(minNum)
 
   def maxToPrecision: BigDecimal = precisionModifier * BigDecimal(maxNum)
-
-  def outcomesToPrecision: Vector[BigDecimal] =
-    outcomeNums.map(num => precisionModifier * BigDecimal(num))
 
   def containsToPrecision(outcome: BigDecimal): Boolean = {
     (outcome / precisionModifier).toBigIntExact match {
@@ -392,15 +380,6 @@ case class RangeEventDescriptorV0TLV(
     start.bytes ++ count.bytes ++ step.bytes ++
       unitSize.bytes ++ unitBytes ++ precision.bytes
   }
-
-  lazy val outcomeInts: Vector[Int32] =
-    NumericRange
-      .inclusive[Long](start.toLong, maxNum.toLong, step.toLong)
-      .toVector
-      .map(Int32(_))
-
-  override lazy val outcomes: Vector[Vector[String]] =
-    outcomeInts.map(num => Vector(num.toLong.toString))
 
   override def noncesNeeded: Int = 1
 }
@@ -470,33 +449,6 @@ trait DigitDecompositionEventDescriptorV0TLV extends NumericEventDescriptor {
     val unitBytes = CryptoUtil.serializeForHash(unit)
 
     base.bytes ++ isSignedByte ++ unitSize.bytes ++ unitBytes ++ precision.bytes ++ numDigitBytes
-  }
-
-  /** WARNING: For large ranges of outcomes, this can take a lot of memory. */
-  override lazy val outcomes: Vector[Vector[String]] = {
-    val legalDigits = 0.until(base.toInt).toVector.map(_.toString)
-
-    val nonNegativeOutcomes = {
-      // All numbers of size (0 to numDigits)
-      var allNumsSoFar = Vector(Vector.empty[String])
-
-      0.until(numDigits.toInt).foreach { _ =>
-        allNumsSoFar = legalDigits.flatMap { num =>
-          allNumsSoFar.map { digits => num +: digits }
-        }
-      }
-
-      allNumsSoFar
-    }
-
-    if (isSigned) {
-      val negativeOutcomes = nonNegativeOutcomes.tail.reverse.map("-" +: _)
-      val positiveOutcomes = nonNegativeOutcomes.map("+" +: _)
-
-      negativeOutcomes ++ positiveOutcomes
-    } else {
-      nonNegativeOutcomes
-    }
   }
 
   override def noncesNeeded: Int = {


### PR DESCRIPTION
This is the same as #6 except it removes all `outcome` related fields where all the outcomes were enumerated. As @nkohen  points out it is a DOS vector and doesn't have a clear use case. 